### PR TITLE
Delete duplicate `robots.txt`

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,2 +1,0 @@
-# https://www.robotstxt.org/robotstxt.html
-User-agent: *


### PR DESCRIPTION
It seems the `robots.txt` in `./public` is the only one used