### PR TITLE
Adjust menu links styles on mobile, to avoid overlap

### DIFF
--- a/src/components/MenuPanel.js
+++ b/src/components/MenuPanel.js
@@ -187,7 +187,7 @@ function MenuFooter({ to, icon, iconActive, label, onActivate }) {
         display: flex;
         flex-direction: column;
         position: fixed;
-        bottom: ${GU}px;
+        bottom: ${layoutSmall ? GU * 0.5 : GU}px;
         width: 100%;
       `}
     >
@@ -198,7 +198,7 @@ function MenuFooter({ to, icon, iconActive, label, onActivate }) {
           flex-direction: column;
           align-items: start;
           margin-left: ${GU * 3}px;
-          margin-bottom: ${GU * 2}px;
+          margin-bottom: ${layoutSmall ? GU * 0.5 : GU * 2}px;
         `}
       >
         <Link


### PR DESCRIPTION
Adjust menu links styles to avoid text overlap.

There's no more overlap on the last menu option, first link option
![image](https://user-images.githubusercontent.com/5571755/120904399-8192c780-c622-11eb-8360-3147d4219f53.png)
