### PR TITLE
Fix: show only allocPoint higher than zero

### DIFF
--- a/src/components/Farming/FarmTable/index.js
+++ b/src/components/Farming/FarmTable/index.js
@@ -37,7 +37,7 @@ const FarmTable = props => {
   const { pairData, searchValue, balance } = props
   const poolInfo = useFetchPoolInfo()
 
-  const pairs = pairData || []
+  const pairs = pairData ? pairData.filter(pair => pair.allocPoint > 0) : []
   const fuse = new Fuse(pairs, {
     keys: [
       'pairInfo.token0.name',


### PR DESCRIPTION
Pools in the Farm with allocPoints zero shouldnt be listed.